### PR TITLE
Add fetchMantelas3

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,13 +1,12 @@
 'use strict';
 
-
 /**
  * Mantela を芋蔓式に取得する
  * @param { string | URL | Request } firstMantela - 起点となる Mantela
- * @param { number } [maxDepth = Infinity] - Mantela を辿る最大深さ
+ * @param { object } [optArgs = { }] - 追加の引数
  */
 async function
-fetchMantelas2(firstMantela, maxDepth = Infinity)
+fetchMantelas3(firstMantela, optArgs = { })
 {
     /** @type { Map<string, { mantela: Mantela }> } */
     const mantelas = new Map();
@@ -17,6 +16,12 @@ fetchMantelas2(firstMantela, maxDepth = Infinity)
 
     /** @type { Set<string | URL | Request> } */
     const visited = new Set();
+
+    /** @type { Error[] } */
+    const errors = [ ];
+
+    /** @type { number } */
+    const maxDepth = optArgs?.maxDepth || Infinity;
 
     /* 負の深さは許されない */
     if (maxDepth < 0)
@@ -55,6 +60,7 @@ fetchMantelas2(firstMantela, maxDepth = Infinity)
             /* 失敗していたらとりあえず console.error に報告して何もしない */
             if (e.status === 'rejected') {
                 console.error(e.reason);
+                errors.push(e.reason);
                 return;
             }
 
@@ -85,6 +91,25 @@ fetchMantelas2(firstMantela, maxDepth = Infinity)
         });
     }
 
+    return { mantelas, errors };
+}
+
+/**
+ * Mantela を芋蔓式に取得する（非推奨; c.f.: fetchMantelas3）
+ * @param { string | URL | Request } firstMantela - 起点となる Mantela
+ * @param { number } [maxDepth = Infinity] - Mantela を辿る最大深さ
+ * @param { Error[] } [errs = undefined] - エラーの一覧
+ */
+async function
+fetchMantelas2(firstMantela, maxDepth = Infinity, errs = undefined)
+{
+    const { mantelas, errors } = await fetchMantelas3(firstMantela, {
+        maxDepth: maxDepth,
+    });
+    if (Array.isArray(errs)) {
+        errs.length = 0;
+        errors.forEach(e => errs.push(e));
+    }
     return mantelas;
 }
 

--- a/fetch.js
+++ b/fetch.js
@@ -98,18 +98,13 @@ fetchMantelas3(firstMantela, optArgs = { })
  * Mantela を芋蔓式に取得する（非推奨; c.f.: fetchMantelas3）
  * @param { string | URL | Request } firstMantela - 起点となる Mantela
  * @param { number } [maxDepth = Infinity] - Mantela を辿る最大深さ
- * @param { Error[] } [errs = undefined] - エラーの一覧
  */
 async function
-fetchMantelas2(firstMantela, maxDepth = Infinity, errs = undefined)
+fetchMantelas2(firstMantela, maxDepth = Infinity)
 {
-    const { mantelas, errors } = await fetchMantelas3(firstMantela, {
+    const { mantelas } = await fetchMantelas3(firstMantela, {
         maxDepth: maxDepth,
     });
-    if (Array.isArray(errs)) {
-        errs.length = 0;
-        errors.forEach(e => errs.push(e));
-    }
     return mantelas;
 }
 

--- a/index.html
+++ b/index.html
@@ -89,8 +89,11 @@ Mantela を辿る最大深さを指定します。
 </fieldset>
 </form>
 <h3>取得結果</h3>
-<dl id="outputList">
-</dl>
+<details>
+<summary id="summaryError">エラー情報</summary>
+<output id="outputError"></output>
+</details>
+<dl id="outputList"></dl>
 </section>
 </main>
 </body>

--- a/index.html
+++ b/index.html
@@ -20,9 +20,168 @@
 </header>
 <main>
 <section>
+<h2>はじめに</h2>
+<p>
+Mantela Fetcher では Mantela で記述された電話局同士のつながりを一括で効率的に取得するための関数を定義しています。
+<s>プログラマが思慮深くなかったことにより</s>歴史的な理由により、以下の関数が定義されています。
+現在、利用の最も推奨される関数は <code>fetchMantelas3()</code> です。
+</p>
+<ul>
+<li><a href="#fetchMantelas3"><code>fetchMantelas3()</code></a></li>
+<li><a href="#fetchMantelas2"><code>fetchMantelas2()</code></a></li>
+<li><a href="#fetchMantelas"><code>fetchMantelas()</code></a></li>
+</ul>
+</section>
+<hr>
+<section id="fetchMantelas3">
+<h2><code>fetchMantelas3()</code> について</h2>
+<p>
+<code>fetchMantelas3()</code> は、<a href="https://github.com/tkytel/mantela">Mantela</a> で記述された電話局同士のつながりを一括で効率的に取得するための関数です。
+</p>
+<section>
+<h3>構文</h3>
+<pre><code>fetchMantelas3(firstMantela)
+fetchMantelas3(firstMantela, optArgs)</code></pre>
+</section>
+<section>
+<h3>引数</h3>
+<dl>
+<dt><code>firstMantela</code></dt>
+<dd><p>
+電話網の起点となる Mantela を指定します。
+文字列や文字列化できるオブジェクト、あるいは <code>Request</code> オブジェクトを使用できます。
+</p></dd>
+<dt><code>optArgs</code>（省略可）</dt>
+<dd><p>
+その他のパラメータを指定します。
+次のようなプロパティを持つオブジェクトです。
+</p>
+<dl>
+<dt><code>maxDepth</code></dt>
+<dd><p>
+Mantela を辿る最大深さを指定します。
+非負の値を指定できます。
+省略された場合、<code>Infinity</code> が指定されたようにふるまいます。
+</p></dd>
+</dl>
+</dl>
+</section>
+<section>
+<h3>返却値</h3>
+<p>
+<code>Promise</code> です。
+次のプロパティを持つオブジェクトに解決します。
+</p>
+<dl>
+<dt><code>mantelas</code></dt>
+<dd><p>
+<code>Map</code> です。
+キーはそれぞれの Mantela の <code>aboutMe.identifier</code> です。
+対応する値は次のプロパティを持つオブジェクトです。
+</p>
+<dl>
+<dt><code>mantela</code></dt>
+<dd><p>
+オブジェクト化された Mantela です。
+</p></dd>
+<dt><code>depth</code></dt>
+<dd><p>
+電話網の起点からの深さです。
+</p></dd>
+</dl>
+</dd>
+<dt><code>errors</code></dt>
+<dd><p>
+配列です。
+要素はエラーとなった Mantela に関する情報を表す <code>Error</code> オブジェクトです。
+各プロパティには次の情報が対応しています。
+</p>
+<dl>
+<dt><code>message</code></dt>
+<dd><p>
+エラーとなった Mantela の URI です。
+</p></dd>
+<dt><code>cause</code></dt>
+<dd><p>
+エラーの原因を表すオブジェクトです。
+</p></dd>
+</dl>
+</dd>
+</dl>
+</section>
+<section>
+<h3>例外</h3>
+<dl>
+<dt><code>RangeError</code></dt>
+<dd><p>
+引数 <code>optArgs</code> のプロパティ <code>maxDepth</code> が負であるときに生起します。
+</p></dd>
+</dl>
+</section>
+</section>
+<hr>
+<section id="fetchMantelas2">
+<h2><code>fetchMantelas2()</code> について</h2>
+<p>
+<code>fetchMantelas2()</code> は、<a href="https://github.com/tkytel/mantela">Mantela</a> で記述された電話局同士のつながりを一括で効率的に取得するための関数です。
+</p>
+<p>
+<strong><code>fetchMantelas2()</code> は互換性のためだけに提供されています。
+新しい実装でこの関数を利用しないでください。</strong>
+<code>fetchMantelas2()</code> は <code>fetchMantelas3()</code> のラッパとして実装されています。
+そのため、<code>fetchMantelas3()</code> に変更が加えられた場合、<code>fetchMantelas2()</code> のふるまいが変化する可能性があります。
+</p>
+<section>
+<h3>構文</h3>
+<pre><code>fetchMantelas2(firstMantela)
+fetchMantelas2(firstMantela, maxDepth)</code></pre>
+</section>
+<section>
+<h3>引数</h3>
+<dl>
+<dt><code>firstMantela</code></dt>
+<dd><p>
+電話網の起点となる Mantela を指定します。
+文字列や文字列化できるオブジェクト、あるいは <code>Request</code> オブジェクトを使用できます。
+</p></dd>
+<dt><code>maxDepth</code>（省略可）</dt>
+<dd><p>
+Mantela を辿る最大深さを指定します。
+非負の値を指定できます。
+省略された場合、<code>Infinity</code> が指定されます。
+</p></dd>
+</dl>
+</section>
+<section>
+<h3>返却値</h3>
+<p>
+<code>Promise</code> です。
+<code>Map</code> に解決します。
+キーはそれぞれの Mantela の <code>aboutMe.identifier</code> です。
+対応する値はオブジェクトであり、プロパティ <code>mantela</code> にオブジェクト化された Mantela を持ちます。
+</p>
+</section>
+<section>
+<h3>例外</h3>
+<dl>
+<dt><code>RangeError</code></dt>
+<dd><p>
+引数 <code>maxDepth</code> が負であるときに生起します。
+</p></dd>
+</dl>
+</section>
+</section>
+<hr>
+<section id="fetchMantelas">
 <h2><code>fetchMantelas()</code> について</h2>
 <p>
 <code>fetchMantelas()</code> は、<a href="https://github.com/tkytel/mantela">Mantela</a> で記述された電話局同士のつながりを一括で効率的に取得するための関数です。
+</p>
+<p>
+<strong><code>fetchMantelas()</code> は互換性のためだけに提供されています。
+新しい実装でこの関数を利用しないでください。</strong>
+<code>fetchMantelas()</code> は <code>fetchMantelas2()</code> のラッパとして実装されています。
+そのため、<code>fetchMantelas2()</code> に変更が加えられた場合、<code>fetchMantelas()</code> のふるまいが変化する可能性があります。
 </p>
 <section>
 <h3>構文</h3>
@@ -62,6 +221,7 @@ Mantela を辿る最大深さを指定します。
 </dl>
 </section>
 </section>
+<hr>
 <section>
 <h2>動作例</h2>
 <form id="formMantela">

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@ Mantela を辿る最大深さを指定します。
 <h3>取得結果</h3>
 <details>
 <summary id="summaryError">エラー情報</summary>
-<output id="outputError"></output>
+<dl id="outputError"></dl>
 </details>
 <dl id="outputList"></dl>
 </section>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@ fetchMantelas3(firstMantela, optArgs)</code></pre>
 次のようなプロパティを持つオブジェクトです。
 </p>
 <dl>
-<dt><code>maxDepth</code></dt>
+<dt><code>maxDepth</code>（省略可）</dt>
 <dd><p>
 Mantela を辿る最大深さを指定します。
 非負の値を指定できます。

--- a/index.js
+++ b/index.js
@@ -16,8 +16,6 @@ formMantela.addEventListener('submit', async e => {
 	outputStatus.textContent = `Done.  (${stop - start} ms)`;
 	btnGenerate.disabled = false;
 
-	console.debug(mantelas)
-
 	const cloneList = outputList.cloneNode(false);
 	outputList.parentNode.replaceChild(cloneList, outputList);
 	mantelas.forEach((v, k) => {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ formMantela.addEventListener('submit', async e => {
 				'Mantela.json の取得に失敗した可能性があります'
 				+ '（正しい URL であるか確認してみてください）',
 			SyntaxError: /* may be thrown by res.json() */
-				'Manela.json の解釈に失敗した可能性があります'
+				'Mantela.json の解釈に失敗した可能性があります'
 				+ '（書式に問題がないか確認してみてください）',
 		}[e.cause.name] || '不明なエラーです';
 


### PR DESCRIPTION
fetchMantelas2 を互換のために残し、これの第三引数をエラー報告のためのリストを受け取るポインタとして利用します（つまり、fetchMantelas2 の第三引数は出力です）。 それはさておき、よりマトモな実装である fetchMantelas3 を用意します。 fetchMantelas2 は fetchMantelas3 のラッパとして実装されなおします。